### PR TITLE
Thinclude titles and typeform modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "react": "^15.6.1",
     "react-burger-menu": "^2.1.1",
     "react-dom": "^15.6.1",
+    "react-helmet": "^5.2.0",
     "react-onscroll": "^1.0.4",
     "react-resize-detector": "^0.6.0",
     "react-router-dom": "^4.1.1",

--- a/src/layouts/About.js
+++ b/src/layouts/About.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ScrollEvent from 'react-onscroll';
+import { Helmet } from 'react-helmet';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import MotionCircle from '../components/MotionCircle';
@@ -63,6 +64,9 @@ class About extends Component {
     const { vacancies, sticky } = this.state;
     return (
       <div className="l-about">
+        <Helmet>
+          <title>Radiant-Earth | About</title>
+        </Helmet>
         <Header currentPath={pathname} />
         <ScrollEvent handleScrollCallback={() => this.handleScrollCallback()} />
         <div className={`l-about__cover ${sticky ? '-sticky' : ''}`}>

--- a/src/layouts/Explore.js
+++ b/src/layouts/Explore.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Swipeable } from 'react-touch';
 import ScrollEvent from 'react-onscroll';
+import { Helmet } from 'react-helmet';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import BoxTitleContent from '../components/BoxTitleContent';
@@ -84,6 +85,10 @@ class Explore extends Component {
     const { pathname } = this.props.location;
     return (
       <div>
+        <Helmet>
+          <script id="typef_orm_share" src="https://embed.typeform.com/embed.js">{}</script>
+          <title>Radiant-Earth | Explore</title>
+        </Helmet>
         <Header currentPath={pathname} />
         <ScrollEvent handleScrollCallback={() => this.handleScrollCallback()} />
         <div className={`l-explore ${sticky ? '-sticky' : ''}`}>
@@ -113,10 +118,12 @@ class Explore extends Component {
                         text={item.text}
                       />
                       {i === 0 && <div className="container-buttons">
-                        <button
-                          onClick={() => this.showModal()}
-                          className="c-button -back-white text -ff2-xs -uppercase -gray"
-                        >REQUEST ACCESS</button>
+                        <a
+                          target="_black"
+                          data-mode="popup"
+                          href="https://radiantearth.typeform.com/to/MLG7bC"
+                          className="c-button -flex -back-white text -ff2-xs -uppercase typeform-share link"
+                        >REQUEST ACCESS</a>
                         <div className="c-button -back-orange">
                           <a className="text -ff2-xs -color-2 -uppercase -white" href="https://app.radiant.earth/login" target="_blank" rel="noopener noreferrer">login</a>
                         </div>

--- a/src/layouts/GetInvolved.js
+++ b/src/layouts/GetInvolved.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-select-me';
 import ScrollEvent from 'react-onscroll';
+import { Helmet } from 'react-helmet';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import BoxTitleContent from '../components/BoxTitleContent';
@@ -98,6 +99,9 @@ class GetInvolved extends Component {
     const { pathname } = this.props.location;
     return (
       <div>
+        <Helmet>
+          <title>Radiant-Earth | Get Involved</title>
+        </Helmet>
         <Header currentPath={pathname} />
         <ScrollEvent handleScrollCallback={() => this.handleScrollCallback()} />
         <div className={`l-get-involved ${sticky ? '-sticky' : ''}`}>

--- a/src/layouts/Home.js
+++ b/src/layouts/Home.js
@@ -3,6 +3,7 @@ import Slider from 'react-slick';
 import { Swipeable } from 'react-touch';
 import ReactResizeDetector from 'react-resize-detector';
 import ScrollEvent from 'react-onscroll';
+import { Helmet } from 'react-helmet';
 import BoxModal from '../components/BoxModal';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
@@ -190,6 +191,9 @@ class Home extends Component {
 
     return (
       <div>
+        <Helmet>
+          <script id="typef_orm_share" src="https://embed.typeform.com/embed.js">{}</script>
+        </Helmet>
         <ScrollEvent handleScrollCallback={() => this.handleScrollCallback()} />
         <Header color="white" />
         <div className={`l-home ${sticky ? '-sticky' : ''}`}>
@@ -204,10 +208,12 @@ class Home extends Component {
                     <div className="c-button -back-orange">
                       <a className="text -ff2-xs -color-2 -uppercase -white" href={'/#'} rel="noopener noreferrer">explore data</a>
                     </div>
-                    <button
-                      onClick={this.showModal.bind(this)}
-                      className="c-button -back-white text -ff2-xs -uppercase"
-                    >REQUEST ACCESS</button>
+                    <a
+                      target="_black"
+                      data-mode="popup"
+                      href="https://radiantearth.typeform.com/to/MLG7bC"
+                      className="c-button -flex -back-white text -ff2-xs -uppercase typeform-share link"
+                    >REQUEST ACCESS</a>
                   </div>}
                 </div>
               )

--- a/src/layouts/News.js
+++ b/src/layouts/News.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Swipeable } from 'react-touch';
 import browser from 'detect-browser';
 import ScrollEvent from 'react-onscroll';
+import { Helmet } from 'react-helmet';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import BoxTitleContent from '../components/BoxTitleContent';
@@ -88,6 +89,9 @@ class News extends Component {
     const { pathname } = this.props.location;
     return (
       <div>
+        <Helmet>
+          <title>Radiant-Earth | News</title>
+        </Helmet>
         <Header currentPath={pathname} />
         <ScrollEvent handleScrollCallback={() => this.handleScrollCallback()} />
         <div className={`l-news ${sticky ? '-sticky' : ''}`}>

--- a/src/layouts/OurTeam.js
+++ b/src/layouts/OurTeam.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ScrollEvent from 'react-onscroll';
+import { Helmet } from 'react-helmet';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
 import { API_BASE_URL, API_ROOT } from '../global';
@@ -74,6 +75,9 @@ class OurTeam extends Component {
     const { pathname } = this.props.location;
     return (
       <div className="l-team">
+        <Helmet>
+          <title>Radiant-Earth | Our Team</title>
+        </Helmet>
         <Header currentPath={pathname} />
         <ScrollEvent handleScrollCallback={() => this.handleScrollCallback()} />
         <div className={`l-team__board ${sticky ? '-sticky' : ''}`}>

--- a/src/styles/components/_Button.scss
+++ b/src/styles/components/_Button.scss
@@ -4,6 +4,12 @@
   border-radius: rem(100px);
   cursor: pointer;
 
+  &.-flex{
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
   &.-back-orange {
     background-color: $color-2;
     color: $white;


### PR DESCRIPTION
## Overview

This PR include:
- Include typeform modal.
- Include news titles on tabs.

## Demo

- Title names:
![image](https://user-images.githubusercontent.com/8074563/30771880-56e677fc-a051-11e7-8878-da7c55ec5f87.png)

- Typeform modal:
![typeform](https://user-images.githubusercontent.com/8074563/30771893-956d4aa0-a051-11e7-972f-e0678ff5e5b1.gif)

## Notes

Include Helmet library -> [react-helmet](https://github.com/nfl/react-helmet)

## Testing

- Click on "request access" button to open typeform modal.
