### PR TITLE
Add custom loaders on all pages

### DIFF
--- a/src/layouts/News.js
+++ b/src/layouts/News.js
@@ -21,7 +21,9 @@ class News extends Component {
       gridNews: [],
       gridShowNumber: 0,
       widthCircle: 510,
-      sticky: false
+      sticky: false,
+      loaderSlider: false,
+      loaderGrid: false
     };
 
     this.getSliderNews = this.getSliderNews.bind(this);
@@ -49,7 +51,10 @@ class News extends Component {
     const self = this;
     fetch(`${API_BASE_URL}/posts?per_page=4`)
       .then(r => r.json())
-      .then(data => self.setState({ sliderNews: data }));
+      .then(data => self.setState({
+        sliderNews: data,
+        loaderSlider: data.length !== 0
+      }));
   }
 
   getGridNews() {
@@ -58,7 +63,8 @@ class News extends Component {
       .then(r => r.json())
       .then(data => self.setState({
         gridNews: data,
-        gridShowNumber: this.state.gridShowNumber + 3
+        gridShowNumber: this.state.gridShowNumber + 3,
+        loaderGrid: data.length !== 0
       }));
   }
 
@@ -86,6 +92,7 @@ class News extends Component {
     const browserSafari = browser.name === 'safari';
     const browserIOS = browser.name === 'ios';
     const { slider, sliderNews, gridNews, widthCircle, sticky } = this.state;
+    const { loaderSlider, loaderGrid } = this.state;
     const { pathname } = this.props.location;
     return (
       <div>
@@ -100,7 +107,25 @@ class News extends Component {
             onSwipeRight={() => this.changeSlider(slider - 1)}
           >
             <div className="l-news__cover">
-              <div className="row">
+              {loaderSlider === false && <div className="row">
+                <div className={`columns large-6 medium-6 small-12 l-news__image ${browserSafari ? '-safari' : ''} ${browserIOS ? '-safari' : ''}`}>
+                  <div className="circle-image">
+                    <MotionCircle move={false} width={widthCircle.toString()} />
+                  </div>
+                </div>
+                <div className="columns large-6 medium-6 small-12 l-news__text-cover">
+                  <div className="text-cover-contain">
+                    <div className="columns c-box-loader -slider">
+                      <div className="timeline-item">
+                        <div className="animated-background">{}</div>
+                        <div className="animated-background -m">{}</div>
+                        <div className="animated-background -m">{}</div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>}
+              {loaderSlider && <div className="row">
                 <div className={`columns large-6 medium-6 small-12 l-news__image ${browserSafari ? '-safari' : ''} ${browserIOS ? '-safari' : ''}`}>
                   {sliderNews.map((item, i) =>
                     (<div key={i.toString()} className={`circle-image ${i === slider ? '-show' : '-hidden'}`}>
@@ -130,11 +155,47 @@ class News extends Component {
                     </button>)
                   )}
                 </ul>
-              </div>
+              </div>}
             </div>
           </Swipeable>
           <div className="l-news__gallery">
-            <div className="row">
+            {loaderGrid === false && <div className="row">
+              <div className="c-box-loader -back columns large-4 medium-6 small-12">
+                <div className="timeline-item">
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background -s">{}</div>
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -footer">{}</div>
+                </div>
+              </div>
+              <div className="c-box-loader -back columns large-4 medium-6 small-12">
+                <div className="timeline-item">
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background -s">{}</div>
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -footer">{}</div>
+                </div>
+              </div>
+              <div className="c-box-loader -back columns large-4 medium-6 small-12">
+                <div className="timeline-item">
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -s">{}</div>
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -footer">{}</div>
+                </div>
+              </div>
+            </div>}
+
+            {loaderGrid && <div className="row">
               {gridNews.map((item, i) =>
                 (<BoxCard
                   key={i.toString()}
@@ -154,7 +215,8 @@ class News extends Component {
                   onClick={() => this.getGridNews()}
                 >load more</button>
               </div>
-            </div>
+            </div>}
+
           </div>
         </div>
         <Footer />

--- a/src/layouts/OurTeam.js
+++ b/src/layouts/OurTeam.js
@@ -14,7 +14,11 @@ class OurTeam extends Component {
       members: [],
       staff: [],
       fellows: [],
-      interns: []
+      interns: [],
+      loaderBoard: false,
+      loaderStaff: false,
+      loaderFellows: false,
+      loaderInterns: false
     };
 
     this.getBoardDirectors = this.getBoardDirectors.bind(this);
@@ -34,28 +38,40 @@ class OurTeam extends Component {
     const self = this;
     fetch(`${API_BASE_URL}/members?is_board_member=true`)
       .then(r => r.json())
-      .then(data => self.setState({ members: data }));
+      .then(data => self.setState({
+        members: data,
+        loaderBoard: data.length !== 0
+      }));
   }
 
   getStaff= () => {
     const self = this;
     fetch(`${API_BASE_URL}/members?category=Staff`)
       .then(r => r.json())
-      .then(data => self.setState({ staff: data }));
+      .then(data => self.setState({
+        staff: data,
+        loaderStaff: data.length !== 0
+      }));
   }
 
   getFellows= () => {
     const self = this;
     fetch(`${API_BASE_URL}/members?category=Fellows`)
       .then(r => r.json())
-      .then(data => self.setState({ fellows: data }));
+      .then(data => self.setState({
+        fellows: data,
+        loaderFellows: data.length !== 0
+      }));
   }
 
   getInterns= () => {
     const self = this;
     fetch(`${API_BASE_URL}/members?category=Interns`)
       .then(r => r.json())
-      .then(data => self.setState({ interns: data }));
+      .then(data => self.setState({
+        interns: data,
+        loaderInterns: data.length !== 0
+      }));
   }
 
   handleScrollCallback() {
@@ -71,7 +87,8 @@ class OurTeam extends Component {
   }
 
   render() {
-    const { members, staff, fellows, interns, sticky } = this.state;
+    const { members, staff, fellows, interns, sticky, loaderBoard } = this.state;
+    const { loaderFellows, loaderInterns, loaderStaff } = this.state;
     const { pathname } = this.props.location;
     return (
       <div className="l-team">
@@ -85,16 +102,42 @@ class OurTeam extends Component {
             <h2
               className="text -ff2-xs -color-2 columns -uppercase large-12 medium-12 small-12"
             >Board of Directors</h2>
-            {members.map((item, i) =>
-              (<div
-                key={i.toString()}
-                className="l-about__board-item columns large-3 medium-4 small-6"
-              >
-                <div className="img" style={{ backgroundImage: `url(${API_ROOT}${item.image})` }}>{}</div>
-                <span className="text -ff2-xs -uppercase">{item.title}</span>
-                <h3 className="text -ff2-l -color-1">{item.name}</h3>
-              </div>)
-            )}
+            {loaderBoard === false && <div className="row l-team__loader-container">
+              <div className="columns c-box-loader -small large-3 medium-4 small-6">
+                <div className="timeline-item">
+                  <div className="animated-background -circle">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background -m">{}</div>
+                </div>
+              </div>
+              <div className="columns c-box-loader -small large-3 medium-4 small-6">
+                <div className="timeline-item">
+                  <div className="animated-background -circle">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background -s">{}</div>
+                </div>
+              </div>
+              <div className="columns c-box-loader -small large-3 medium-4 small-6">
+                <div className="timeline-item">
+                  <div className="animated-background -circle">{}</div>
+                  <div className="animated-background ">{}</div>
+                  <div className="animated-background -s">{}</div>
+                </div>
+              </div>
+            </div>}
+            { loaderBoard && <div className="flex">
+              {members.map((item, i) =>
+                (<div
+                  key={i.toString()}
+                  className="l-about__board-item columns large-3 medium-4 small-6"
+                >
+                  <div className="img" style={{ backgroundImage: `url(${API_ROOT}${item.image})` }}>{}</div>
+                  <span className="text -ff2-xs -uppercase">{item.title}</span>
+                  <h3 className="text -ff2-l -color-1">{item.name}</h3>
+                </div>)
+              )}
+            </div>}
+
           </div>
         </div>
         <div className="l-team__content">
@@ -102,22 +145,51 @@ class OurTeam extends Component {
             <h2
               className="text -ff2-xs -color-2 columns -uppercase large-12 medium-12 small-12"
             >STAFF</h2>
-            {staff.map((item, i) =>
-              (<div className="columns large-6 medium-12 small-12" key={i.toString()}>
-                <div className="l-about__team-item">
-                  <div className="contain-info">
-                    <div className="img" style={{ backgroundImage: `url(${API_ROOT}${item.image})` }}>{}</div>
-                    <div className="info">
-                      <span className="text -ff2-xs -uppercase">{item.title}</span>
-                      <h3 className="text -ff2-l -color-1">{item.name}</h3>
+
+            {loaderStaff === false && <div className="l-team__loader-container -flex">
+              <div className="c-box-loader -primary columns large-6 medium-12 small-12">
+                <div className="timeline-item">
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background -s">{}</div>
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -footer">{}</div>
+                </div>
+              </div>
+              <div className="c-box-loader -primary columns large-6 medium-12 small-12">
+                <div className="timeline-item">
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background -s">{}</div>
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background">{}</div>
+                  <div className="animated-background -footer">{}</div>
+                </div>
+              </div>
+            </div> }
+
+            {loaderStaff && <div className="flex">
+              {staff.map((item, i) =>
+                (<div className="columns large-6 medium-12 small-12" key={i.toString()}>
+                  <div className="l-about__team-item">
+                    <div className="contain-info">
+                      <div className="img" style={{ backgroundImage: `url(${API_ROOT}${item.image})` }}>{}</div>
+                      <div className="info">
+                        <span className="text -ff2-xs -uppercase">{item.title}</span>
+                        <h3 className="text -ff2-l -color-1">{item.name}</h3>
+                      </div>
+                    </div>
+                    <div className="contain-text">
+                      <p className="text -ff1-m">{item.description}</p>
                     </div>
                   </div>
-                  <div className="contain-text">
-                    <p className="text -ff1-m">{item.description}</p>
-                  </div>
-                </div>
-              </div>)
-            )}
+                </div>)
+              )}
+            </div>}
+
           </div>
         </div>
         <div className="l-team__fellows">
@@ -125,16 +197,41 @@ class OurTeam extends Component {
             <h2
               className="text -ff2-xs -color-2 columns -uppercase large-12 medium-12 small-12"
             >Fellows</h2>
-            {fellows.map((item, i) =>
-              (<div
-                key={i.toString()}
-                className="l-about__fellows-item columns large-3 medium-4 small-6"
-              >
-                <div className="img" style={{ backgroundImage: `url(${API_ROOT}${item.image})` }}>{}</div>
-                <span className="text -ff2-xs -uppercase">{item.title}</span>
-                <h3 className="text -ff2-l -color-1">{item.name}</h3>
-              </div>)
-            )}
+            {loaderFellows === false && <div className="row l-team__loader-container">
+              <div className="columns c-box-loader -small large-3 medium-4 small-6">
+                <div className="timeline-item">
+                  <div className="animated-background -circle">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background -m">{}</div>
+                </div>
+              </div>
+              <div className="columns c-box-loader -small large-3 medium-4 small-6">
+                <div className="timeline-item">
+                  <div className="animated-background -circle">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background -s">{}</div>
+                </div>
+              </div>
+              <div className="columns c-box-loader -small large-3 medium-4 small-6">
+                <div className="timeline-item">
+                  <div className="animated-background -circle">{}</div>
+                  <div className="animated-background ">{}</div>
+                  <div className="animated-background -s">{}</div>
+                </div>
+              </div>
+            </div>}
+            {loaderFellows && <div className="flex">
+              {fellows.map((item, i) =>
+                (<div
+                  key={i.toString()}
+                  className="l-about__fellows-item columns large-3 medium-4 small-6"
+                >
+                  <div className="img" style={{ backgroundImage: `url(${API_ROOT}${item.image})` }}>{}</div>
+                  <span className="text -ff2-xs -uppercase">{item.title}</span>
+                  <h3 className="text -ff2-l -color-1">{item.name}</h3>
+                </div>)
+              )}
+            </div>}
           </div>
         </div>
         <div className="l-team__interns">
@@ -142,16 +239,35 @@ class OurTeam extends Component {
             <h2
               className="text -ff2-xs -color-2 columns -uppercase large-12 medium-12 small-12"
             >Interns</h2>
-            {interns.map((item, i) =>
-              (<div
-                key={i.toString()}
-                className="l-about__interns-item columns large-3 medium-4 small-6"
-              >
-                <div className="img" style={{ backgroundImage: `url(${API_ROOT}${item.image})` }}>{}</div>
-                <span className="text -ff2-xs -uppercase">{item.title}</span>
-                <h3 className="text -ff2-l -color-1">{item.name}</h3>
-              </div>)
-            )}
+            {loaderInterns === false && <div className="row l-team__loader-container">
+              <div className="columns c-box-loader -small large-3 medium-4 small-6">
+                <div className="timeline-item">
+                  <div className="animated-background -circle">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background -m">{}</div>
+                </div>
+              </div>
+              <div className="columns c-box-loader -small large-3 medium-4 small-6">
+                <div className="timeline-item">
+                  <div className="animated-background -circle">{}</div>
+                  <div className="animated-background -m">{}</div>
+                  <div className="animated-background -s">{}</div>
+                </div>
+              </div>
+            </div>}
+            {loaderInterns && <div className="flex">
+              {interns.map((item, i) =>
+                (<div
+                  key={i.toString()}
+                  className="l-about__interns-item columns large-3 medium-4 small-6"
+                >
+                  <div className="img" style={{ backgroundImage: `url(${API_ROOT}${item.image})` }}>{}</div>
+                  <span className="text -ff2-xs -uppercase">{item.title}</span>
+                  <h3 className="text -ff2-l -color-1">{item.name}</h3>
+                </div>)
+              )}
+            </div>}
+
           </div>
         </div>
         <Footer />

--- a/src/styles/components/_BoxLoader.scss
+++ b/src/styles/components/_BoxLoader.scss
@@ -1,5 +1,4 @@
 .c-box-loader {
-
   .animated-background {
       animation-duration: 1s;
       animation-fill-mode: forwards;
@@ -33,6 +32,12 @@
         margin-top: rem(50px);
         margin-bottom: 0;
       }
+
+      &.-circle {
+        width: rem(70px);
+        height: rem(70px);
+        border-radius: rem(70px);
+      }
   }
 
   &.-primary {
@@ -56,7 +61,6 @@
 
   &.-secondary {
     background: rgba($color-4, .05);
-    padding: 12px;
     min-width: calc(100vw - 40px);
     min-height: rem(394px);
     padding: rem(40px);
@@ -75,6 +79,18 @@
       width: rem(360px);
       min-width: rem(360px);
     }
+  }
+
+  &.-small {
+    min-width: rem(250px);
+    min-height: rem(200px);
+    margin-right: rem(15px);
+  }
+
+  &.-back {
+    background: rgba($color-4, .05);
+    border-right: 15px solid $white;
+    padding: rem(40px);
   }
 }
 

--- a/src/styles/layouts/_OurTeam.scss
+++ b/src/styles/layouts/_OurTeam.scss
@@ -5,6 +5,26 @@
     }
   }
 
+  .flex {
+    display: flex;
+    flex-flow: row wrap;
+    width: 100%;
+  }
+
+  .l-team__loader-container {
+    padding-left: rem(15px);
+    padding-right: rem(15px);
+
+    &.-flex {
+      display: flex;
+      flex-flow: row wrap;
+
+      @media screen and (min-width: $screen-xl) {
+        flex-flow: row;
+      }
+    }
+  }
+
   .l-team__board,
   .l-team__fellows,
   .l-team__interns {


### PR DESCRIPTION
## Overview

This PR include:
- New loader designs (Slider, and team)
- Add loaders on all pages.

## Demo

- Slider loader:
![sliderloader](https://user-images.githubusercontent.com/8074563/30805246-e4a70b6a-a1f0-11e7-9876-0e1234f2342f.gif)


- Team loader:
![teamloader](https://user-images.githubusercontent.com/8074563/30805247-e934348c-a1f0-11e7-9c19-17d3f594ee10.gif)


## Notes

(No notes)

## Testing

- Visit all the pages and test the loaders.
